### PR TITLE
Added deflate-timestamp and inflate-timestamp using UTC

### DIFF
--- a/src/core/dao/mixin.lisp
+++ b/src/core/dao/mixin.lisp
@@ -13,8 +13,18 @@
            #:object-id
            #:object=
            #:object-created-at
-           #:object-updated-at))
+           #:object-updated-at
+
+           #:inflate-timestamp
+           #:deflate-timestamp
+
+           #:+sql-datetime-format+))
 (in-package :mito.dao.mixin)
+
+(defparameter +sql-datetime-format+
+  (append local-time:+iso-8601-date-format+
+          (list #\space)
+          local-time:+iso-8601-time-format+))
 
 (defclass dao-table-mixin (table-class) ())
 
@@ -33,25 +43,29 @@
     (and (eq (class-of object1) (class-of object2))
          (eql (object-id object1) (object-id object2)))))
 
+(defgeneric inflate-timestamp (value)
+  (:method ((value integer))
+   (local-time:universal-to-timestamp value))
+  (:method ((value string))
+   (local-time:parse-timestring value :date-time-separator #\space))
+  (:method ((value null))
+   nil))
+
+(defgeneric deflate-timestamp (value)
+  (:method ((value local-time:timestamp))
+   (local-time:format-timestring nil value
+                                 :format +sql-datetime-format+
+                                 :timezone local-time:+utc-zone+)))
+
 (defclass record-timestamps-mixin ()
   ((created-at :col-type (or :timestamp :null)
                :initarg :created-at
-               :inflate (lambda (value)
-                          (etypecase value
-                            (integer
-                             (local-time:universal-to-timestamp value))
-                            (string
-                             (local-time:parse-timestring value :date-time-separator #\Space))
-                            (null nil)))
+               :inflate #'inflate-timestamp
+               :deflate #'deflate-timestamp
                :accessor object-created-at)
    (updated-at :col-type (or :timestamp :null)
                :initarg :updated-at
-               :inflate (lambda (value)
-                          (etypecase value
-                            (integer
-                             (local-time:universal-to-timestamp value))
-                            (string
-                             (local-time:parse-timestring value :date-time-separator #\Space))
-                            (null nil)))
+               :inflate #'inflate-timestamp
+               :deflate #'deflate-timestamp
                :accessor object-updated-at))
   (:metaclass dao-table-mixin))


### PR DESCRIPTION
Candidate fix for #2. `deflate-timestamp` and `inflate-timestamp` made more easily reusable.
