### PR TITLE
retrieve-by-sql: recursively convert nulls to nils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - curl -L https://raw.githubusercontent.com/snmsts/roswell/release/scripts/install-for-ci.sh | sh
   - ros install prove
   - git clone https://github.com/fukamachi/sxql ~/lisp/sxql
+  - ros install marijnh/Postmodern
 
 cache:
   directories:

--- a/mito-test.asd
+++ b/mito-test.asd
@@ -24,7 +24,8 @@
                  (:test-file "dao")
                  (:test-file "migration/sqlite3")
                  (:test-file "migration/mysql")
-                 (:test-file "migration/postgres"))))
+                 (:test-file "migration/postgres")
+                 (:test-file "postgres-types"))))
   :description "Test system for mito"
 
   :defsystem-depends-on (:prove-asdf)

--- a/src/core/db.lisp
+++ b/src/core/db.lisp
@@ -106,6 +106,31 @@
         (trace-sql sql binds)
         (apply #'dbi:do-sql *connection* sql binds)))))
 
+(defun array-convert-nulls-to-nils (results-array &key (recursive t))
+  (let ((darray (make-array (array-total-size results-array)
+                     :displaced-to results-array
+                     :element-type (array-element-type results-array))))
+    (loop for x across darray
+         for i from 0
+       do (cond ((eq x :null)
+                 (setf (aref darray i) nil))
+                ((and recursive x (listp x))
+                 (setf (aref darray i)
+                       (list-convert-nulls-to-nils x)))
+                ((and recursive x (vectorp x))
+                 (setf (aref darray i)
+                       (array-convert-nulls-to-nils x)))))
+    results-array))
+
+(defun list-convert-nulls-to-nils (results-list &key (recursive t))
+  (mapcar (lambda (x) (cond ((eq x :null) nil)
+                            ((and recursive x (listp x))
+                             (list-convert-nulls-to-nils x))
+                            ((and recursive x (vectorp x))
+                             (array-convert-nulls-to-nils x))
+                            (t x)))
+          results-list))
+
 (defgeneric retrieve-by-sql (sql &key binds)
   (:method :before (sql &key binds)
     (declare (ignore sql binds))
@@ -120,9 +145,12 @@
                    collect
                    (loop for (k v) on result by #'cddr
                          collect (lispify k)
-                         collect (if (eq v :null)
-                                     nil
-                                     v)))))
+                         collect (cond ((eq v :null) nil)
+                                       ((and v (listp v))
+                                        (list-convert-nulls-to-nils v))
+                                       ((arrayp v)
+                                        (array-convert-nulls-to-nils v))
+                                       (t v))))))
 
       (trace-sql sql binds results)
       results))

--- a/t/postgres-types.lisp
+++ b/t/postgres-types.lisp
@@ -1,0 +1,32 @@
+(in-package :cl-user)
+(defpackage mito-test.postgres-types
+  (:use #:cl
+        #:prove
+        #:mito.dao
+        #:mito.connection
+        #:mito-test.util))
+(in-package :mito-test.postgres-types)
+
+(plan nil)
+
+(subtest "retrieve-by-sql"
+  (setf *connection* (connect-to-testdb :postgres))
+  (is (mito:retrieve-by-sql "select row(1,NULL);")
+      '((:ROW (1 NIL))))
+  
+  (is (mito:retrieve-by-sql "select NULL;")
+      '((:?COLUMN? NIL)))
+  
+  (is (mito:retrieve-by-sql "select row(NULL, 'a', NULL);")
+      '((:ROW (NIL "a" NIL))))
+  
+  (is (mito:retrieve-by-sql "select row(ARRAY[NULL, NULL]);")
+      '((:ROW (#(NIL NIL))))
+      :test #'equalp)
+  
+  (is (mito:retrieve-by-sql "select row(ARRAY['bogus', NULL]);")
+      '((:ROW (#("bogus" NIL))))
+      :test #'equalp))
+
+(finalize)
+


### PR DESCRIPTION
 * added convert-nulls-to-nils and list-convert-nulls-to-nils and use
   them in retrieve-by-sql to convert :nulls to nils in lists and arrays