### PR TITLE
Fix issue when using `where-and` with dashed field names

### DIFF
--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -302,7 +302,7 @@
                                                                    (c2mop:slot-definition-name
                                                                     (dao-table-column-foreign-slot child)))))))))
                     else
-                      collect `(:= ,field ,value))))
+                      collect `(:= ,(unlispify field) ,value))))
       (when op
         (sxql:where `(:and ,@op))))))
 


### PR DESCRIPTION
This fixes an issue when using `where-and` with dashed field names. Dashes were not correctly being converted to use underscores which caused `count-dao` to return incorrect results.

For example:

```lisp
(mito:count-dao 'mytable :some-dashed-field "value")
```

Would always return 0, because the generated SQL would not convert dashes to underscores:

```lisp
#<SXQL-CLAUSE: WHERE (some-dashed-field = 'value')>
```

This change adds the missing field name conversion.