### PR TITLE
postgres row value tests

### DIFF
--- a/t/postgres-types.lisp
+++ b/t/postgres-types.lisp
@@ -12,20 +12,40 @@
 (subtest "retrieve-by-sql"
   (setf *connection* (connect-to-testdb :postgres))
   (is (mito:retrieve-by-sql "select row(1,NULL);")
-      '((:ROW (1 NIL))))
+      '((:ROW "(1,)")))
 
   (is (mito:retrieve-by-sql "select NULL;")
       '((:?COLUMN? NIL)))
 
   (is (mito:retrieve-by-sql "select row(NULL, 'a', NULL);")
-      '((:ROW (NIL "a" NIL))))
+      '((:ROW "(,a,)")))
 
   (is (mito:retrieve-by-sql "select row(ARRAY[NULL, NULL]);")
-      '((:ROW (#(NIL NIL))))
+      '((:ROW "(\"{NULL,NULL}\")"))
       :test #'equalp)
 
   (is (mito:retrieve-by-sql "select row(ARRAY['bogus', NULL]);")
-      '((:ROW (#("bogus" NIL))))
+      '((:ROW "(\"{bogus,NULL}\")"))
       :test #'equalp))
+
+(subtest "retrieve-by-sql-binary"
+  (setf *connection* (connect-to-testdb :postgres))
+  (cl-postgres:with-binary-row-values
+    (is (mito:retrieve-by-sql "select row(1,NULL);")
+        '((:ROW (1 NIL))))
+
+    (is (mito:retrieve-by-sql "select NULL;")
+        '((:?COLUMN? NIL)))
+
+    (is (mito:retrieve-by-sql "select row(NULL, 'a', NULL);")
+        '((:ROW (NIL "a" NIL))))
+
+    (is (mito:retrieve-by-sql "select row(ARRAY[NULL, NULL]);")
+        '((:ROW (#(NIL NIL))))
+        :test #'equalp)
+
+    (is (mito:retrieve-by-sql "select row(ARRAY['bogus', NULL]);")
+        '((:ROW (#("bogus" NIL))))
+        :test #'equalp)))
 
 (finalize)


### PR DESCRIPTION
 * fix expected values for text (the default format) row values and add
   new tests for binary row values.

Note that this requires Postmodern version 160ba03c0bf91563dcdce055e185e2f5b3301348 or later for the recent text/binary row value changes and for the null value Postmodern bug fixes.