### PR TITLE
An error "DB Error: database table is locked (Code: LOCKED)" was fixed.

### DIFF
--- a/src/core/db.lisp
+++ b/src/core/db.lisp
@@ -87,7 +87,7 @@
             (sxql:where (:and (:= :name table-name)
                               (:= :type "table")))
             (sxql:limit 1)))))
-    (and (dbi:fetch
+    (and (dbi:fetch-all
           (apply #'dbi:execute (dbi:prepare conn sql) binds))
          t)))
 


### PR DESCRIPTION
This error was appeared when you are trying to generate-migrations for SQL database where some table
already exists.

This commit fixes issue #27.