### PR TITLE
Fix include-foreign-objects to allow contain nil

### DIFF
--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -191,11 +191,12 @@
                    (sxql:from (sxql:make-sql-symbol (table-name foreign-class)))
                    (sxql:where
                     (:in (sxql:make-sql-symbol (table-column-name foreign-slot))
-                         (loop for obj in records
-                               append
-                               (mapcar (lambda (rel-slot)
-                                         (slot-value obj (c2mop:slot-definition-name rel-slot)))
-                                       rel-slots))))))
+                         (remove nil
+                                 (loop for obj in records
+                                       append
+                                       (mapcar (lambda (rel-slot)
+                                                 (slot-value obj (c2mop:slot-definition-name rel-slot)))
+                                               rel-slots)))))))
                (results
                  (select-by-sql foreign-class sql)))
           (dolist (obj records)


### PR DESCRIPTION
Fix so that mito:includes works in the following cases, in which col-type of tel is optional.

```common-lisp
(defclass user ()
  ((name :col-type (:varchar 64)
         :initarg :name
         :accessor user-name)
   (email :col-type (or (:varchar 128) :null)
          :initarg :email
          :accessor user-email)
   (tel :col-type (or optional-info :null)))
  (:metaclass mito:dao-table-class))

(defclass optional-info ()
  ((tel :col-type :text
        :initarg :tel
        :accessor optional-info-tel))
  (:metaclass mito:dao-table-class))

(mito:select-dao 'user (mito:includes 'optional-info))
```