### PR TITLE
Default initargs and accessors

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -39,7 +39,9 @@
                                       #:retrieve-dao
                                       #:count-dao
                                       #:recreate-table
-                                      #:ensure-table-exists))
+                                      #:ensure-table-exists
+
+                                      #:deftable))
 (cl-reexport:reexport-from :mito.db
                            :include '(#:execute-sql
                                       #:retrieve-by-sql))

--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -384,4 +384,6 @@
   `(defclass ,name ,direct-superclasses
      ,direct-slots
      (:metaclass dao-table-class)
+     ,@(unless (find :conc-name options :key #'car)
+         `((:conc-name ,(intern (format nil "~A-" name) (symbol-package name)))))
      ,@options))

--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -52,7 +52,8 @@
                #:retrieve-dao
                #:count-dao
                #:recreate-table
-               #:ensure-table-exists))))
+               #:ensure-table-exists
+               #:deftable))))
 (in-package :mito.dao)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -378,3 +379,9 @@
       (when exists
         (execute-sql (sxql:drop-table (sxql:make-sql-symbol (table-name class)))))
       (mapc #'execute-sql (table-definition class)))))
+
+(defmacro deftable (name direct-superclasses direct-slots &rest options)
+  `(defclass ,name ,direct-superclasses
+     ,direct-slots
+     (:metaclass dao-table-class)
+     ,@options))

--- a/src/core/dao/table.lisp
+++ b/src/core/dao/table.lisp
@@ -172,7 +172,7 @@
      :test #'eq)))
 
 (defmethod initialize-instance :around ((class dao-table-class) &rest initargs
-                                        &key direct-superclasses (conc-name nil conc-name-specified) &allow-other-keys)
+                                        &key direct-superclasses conc-name &allow-other-keys)
   (when (and (initargs-enables-record-timestamps initargs)
              (not (contains-class-or-subclasses 'record-timestamps-mixin direct-superclasses)))
     (setf (getf initargs :direct-superclasses)
@@ -196,16 +196,13 @@
                                                direct-superclasses))))
           (push (find-class auto-pk-class) (getf initargs :direct-superclasses))))))
 
-  (let ((*conc-name* (if conc-name-specified
-                         (first conc-name)
-                         (intern (format nil "~A-" (class-name class))
-                                 (symbol-package (class-name class))))))
+  (let ((*conc-name* (first conc-name)))
     (let ((class (apply #'call-next-method class initargs)))
       (add-relational-readers class initargs)
       class)))
 
 (defmethod reinitialize-instance :around ((class dao-table-class) &rest initargs
-                                          &key direct-superclasses (conc-name nil conc-name-specified) &allow-other-keys)
+                                          &key direct-superclasses conc-name &allow-other-keys)
   (when (and (initargs-enables-record-timestamps initargs)
              (not (contains-class-or-subclasses 'record-timestamps-mixin direct-superclasses)))
     (setf (getf initargs :direct-superclasses)
@@ -226,10 +223,7 @@
                                                direct-superclasses))))
           (push (find-class auto-pk-class) (getf initargs :direct-superclasses))))))
 
-  (let ((*conc-name* (if conc-name-specified
-                         (first conc-name)
-                         (intern (format nil "~A-" (class-name class))
-                                 (symbol-package (class-name class))))))
+  (let ((*conc-name* (first conc-name)))
     (let ((class (apply #'call-next-method class initargs)))
       (add-relational-readers class initargs)
       class)))

--- a/src/core/dao/table.lisp
+++ b/src/core/dao/table.lisp
@@ -19,6 +19,7 @@
                 #:find-slot-by-name
                 #:find-child-columns)
   (:import-from #:mito.dao.column
+                #:*conc-name*
                 #:dao-table-column-class
                 #:dao-table-column-inflate)
   (:import-from #:mito.dao.mixin
@@ -171,7 +172,7 @@
      :test #'eq)))
 
 (defmethod initialize-instance :around ((class dao-table-class) &rest initargs
-                                        &key direct-superclasses &allow-other-keys)
+                                        &key direct-superclasses (conc-name nil conc-name-specified) &allow-other-keys)
   (when (and (initargs-enables-record-timestamps initargs)
              (not (contains-class-or-subclasses 'record-timestamps-mixin direct-superclasses)))
     (setf (getf initargs :direct-superclasses)
@@ -195,12 +196,16 @@
                                                direct-superclasses))))
           (push (find-class auto-pk-class) (getf initargs :direct-superclasses))))))
 
-  (let ((class (apply #'call-next-method class initargs)))
-    (add-relational-readers class initargs)
-    class))
+  (let ((*conc-name* (if conc-name-specified
+                         (first conc-name)
+                         (intern (format nil "~A-" (class-name class))
+                                 (symbol-package (class-name class))))))
+    (let ((class (apply #'call-next-method class initargs)))
+      (add-relational-readers class initargs)
+      class)))
 
 (defmethod reinitialize-instance :around ((class dao-table-class) &rest initargs
-                                                                    &key direct-superclasses &allow-other-keys)
+                                          &key direct-superclasses (conc-name nil conc-name-specified) &allow-other-keys)
   (when (and (initargs-enables-record-timestamps initargs)
              (not (contains-class-or-subclasses 'record-timestamps-mixin direct-superclasses)))
     (setf (getf initargs :direct-superclasses)
@@ -221,9 +226,13 @@
                                                direct-superclasses))))
           (push (find-class auto-pk-class) (getf initargs :direct-superclasses))))))
 
-  (let ((class (apply #'call-next-method class initargs)))
-    (add-relational-readers class initargs)
-    class))
+  (let ((*conc-name* (if conc-name-specified
+                         (first conc-name)
+                         (intern (format nil "~A-" (class-name class))
+                                 (symbol-package (class-name class))))))
+    (let ((class (apply #'call-next-method class initargs)))
+      (add-relational-readers class initargs)
+      class)))
 
 (defmethod c2mop:ensure-class-using-class :around ((class dao-table-class) name &rest keys
                                                    &key direct-superclasses &allow-other-keys)


### PR DESCRIPTION
This is a common pattern of defining a table class:

```common-lisp
(defclass user ()
  ((name :col-type (:varchar 64)
         :initarg :name
         :accessor user-name)
   (email :col-type (or (:varchar 128) :null)
          :initarg :email
          :accessor user-email))
  (:metaclass mito:dao-table-class))
```

With this patch, it can be written like this:

```common-lisp
(mito:deftable user ()
  ((name :col-type (:varchar 64))
   (email :col-type (or (:varchar 128) :null))))
```

`deftable` adds the default `:initarg` and `:accessor`, so those are still available.

```common-lisp
(user-name (make-instance 'user :name "fukamachi'))
;=> "fukamachi"
```

The default accessor prefix can be changed with `:conc-name` class option.

```common-lisp
(mito:deftable user ()
  ((name :col-type (:varchar 64))
   (email :col-type (or (:varchar 128) :null)))
  (:conc-name my-))

(my-name (make-instance 'user :name "fukamachi"))
;=> "fukamachi"
```

If you don't need them, adding `(:conc-name nil)` prevents it.

```common-lisp
(mito:deftable user ()
  ((name :col-type (:varchar 64))
   (email :col-type (or (:varchar 128) :null)))
  (:conc-name nil))
```