### PR TITLE
Added the --host and --port arguments to connect to remote databases.

### DIFF
--- a/roswell/mito.ros
+++ b/roswell/mito.ros
@@ -63,6 +63,8 @@ exec ros -Q -- $0 "$@"
                 (nconcf connect-args (list :password (pop args))))
                (("-H" "--host")
                 (nconcf connect-args (list :host (pop args))))
+               (("-P" "--port")
+                (nconcf connect-args (list :port (parse-integer (pop args)))))
                (("-s" "--system")
                 (push (pop args) systems))
                (("-D" "--directory")

--- a/roswell/mito.ros
+++ b/roswell/mito.ros
@@ -86,6 +86,8 @@ Commands:
 
 Options:
     -t, --type DRIVER-TYPE          DBI driver type (one of \"mysql\", \"postgres\" or \"sqlite3\")
+    -H, --host DATABASE-HOST        Database host to use (default is 127.0.0.1)
+    -P, --port DATABASE-PORT        Database port to use (default is depends on the driver type)
     -d, --database DATABASE-NAME    Database name to use
     -u, --username USERNAME         Username for RDBMS
     -p, --password PASSWORD         Password for RDBMS

--- a/roswell/mito.ros
+++ b/roswell/mito.ros
@@ -61,6 +61,8 @@ exec ros -Q -- $0 "$@"
                 (nconcf connect-args (list :username (pop args))))
                (("-p" "--password")
                 (nconcf connect-args (list :password (pop args))))
+               (("-H" "--host")
+                (nconcf connect-args (list :host (pop args))))
                (("-s" "--system")
                 (push (pop args) systems))
                (("-D" "--directory")


### PR DESCRIPTION
This is useful when your dev database is on a remote server or in a separate docker container.