### PR TITLE
add connection-database-name function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,9 @@ If you want to use a connection lexically, just bind it:
     (dbi:disconnect mito:*connection*)))
 ```
 
+Use `connection-database-name` to get the name of the current
+connection, or of the one given as parameter.
+
 ### deftable macro
 
 As Mito's dao table class is defined as a CLOS metaclass, you can define a table class like this:

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -8,7 +8,8 @@
 (cl-reexport:reexport-from :mito.connection
                            :include '(#:*connection*
                                       #:connect-toplevel
-                                      #:disconnect-toplevel))
+                                      #:disconnect-toplevel
+                                      #:connection-database-name))
 (cl-reexport:reexport-from :mito.dao
                            :include '(#:dao-class
                                       #:dao-table-class

--- a/src/core/connection.lisp
+++ b/src/core/connection.lisp
@@ -8,6 +8,7 @@
                 #:connection-driver-type)
   (:export #:*connection*
            #:driver-type
+           #:connection-database-name
            #:connected-p
            #:check-connected
            #:connect-toplevel
@@ -17,6 +18,10 @@
 (in-package :mito.connection)
 
 (defvar *connection*)
+
+(defun connection-database-name (&optional conn)
+  "Return the name of the current connection, or the one given as argument."
+  (dbi:connection-database-name (or conn *connection*)))
 
 (defun connected-p ()
   (and (boundp '*connection*)


### PR DESCRIPTION
This is just a wrapper around a dbi method, but it is very handy for me and I have wanted this for a long time.  I didn't find easily (enough) about the dbi method, I had to follow layers of sources. Having this is easier for auto-discovery and more handy than inspect.

Regards