### PR TITLE
new variable to control the output stream of with-sql-logging

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -47,5 +47,6 @@
                                       #:retrieve-by-sql))
 (cl-reexport:reexport-from :mito.logger
                            :include '(#:*mito-logger-stream*
+                                      #:*mito-migration-logger-stream*
                                       #:*trace-sql-hooks*))
 (cl-reexport:reexport-from :mito.error)

--- a/src/core/logger.lisp
+++ b/src/core/logger.lisp
@@ -4,6 +4,7 @@
   (:import-from #:alexandria
                 #:delete-from-plist)
   (:export #:*mito-logger-stream*
+           #:*mito-migration-logger-stream*
            #:with-sql-logging
            #:trace-sql
            #:*trace-sql-hooks*))
@@ -11,8 +12,11 @@
 
 (defvar *mito-logger-stream* nil)
 
+(defvar *mito-migration-logger-stream* (make-synonym-stream '*standard-output*)
+  "Stream to output sql generated during migrations.")
+
 (defmacro with-sql-logging (&body body)
-  `(let ((*mito-logger-stream* *standard-output*))
+  `(let ((*mito-logger-stream* *mito-migration-logger-stream*))
      ,@body))
 
 (defun get-prev-stack ()


### PR DESCRIPTION
I want to silence migrations during my unit tests, so I don't want
this macro to always write to standard-output.

I figured that `*mito-logger-stream*` is used elsewhere and is better staying at nil, hence the new variable.

Regards