### PR TITLE
initialize *connection* to nil

### DIFF
--- a/src/core/connection.lisp
+++ b/src/core/connection.lisp
@@ -16,11 +16,10 @@
            #:with-quote-char))
 (in-package :mito.connection)
 
-(defvar *connection*)
+(defvar *connection* nil)
 
 (defun connected-p ()
-  (and (boundp '*connection*)
-       (not (null *connection*))))
+  (not (null *connection*)))
 
 (defun check-connected ()
   (or (connected-p)


### PR DESCRIPTION
This is a minor PR but it could simplify the api.

By default `*connection*` is unbound when we are not connected to a DB.
Now we can always check it without being cautious with a
`(and (boundp ...) ...)` or better `mito:connected-p`.

I don't see the benefits of keeping this variable unbound, when all connected-p does is checking it isn't null, and given the variable is exported and encouraged for use.

Thanks.