### PR TITLE
Change select-dao to return also sxql struct as values

### DIFF
--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -319,7 +319,7 @@
                (let ((,results (select-by-sql ,class ,sql)))
                  (dolist (,foreign-class ,include-classes)
                    (include-foreign-objects ,foreign-class ,results))
-                 ,results))))))))
+                 (values ,results ,sql)))))))))
 
 (defun where-and (fields-and-values class)
   (when fields-and-values


### PR DESCRIPTION
I want to use the sxql struct which is used for querying in select-dao for other purposes(e.g. for paging),
so changed select-dao to return multiple values.