### PR TITLE
Function select-by-sql was exported and now accepts :binds parameter like retrieve-by-sql

### DIFF
--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -46,6 +46,7 @@
                #:delete-by-values
                #:save-dao
                #:select-dao
+               #:select-by-sql
                #:includes
                #:include-foreign-objects
                #:find-dao
@@ -191,10 +192,10 @@
         (update-dao obj)
         (insert-dao obj))))
 
-(defun select-by-sql (class sql)
+(defun select-by-sql (class sql &key binds)
   (mapcar (lambda (result)
             (apply #'make-dao-instance class result))
-          (retrieve-by-sql sql)))
+          (retrieve-by-sql sql :binds binds)))
 
 (defun include-foreign-objects (foreign-class records)
   (when records


### PR DESCRIPTION
This makes possible to write SQL by hand in cases where you need
something complex like that:

    (mito.dao:select-by-sql
     'top-item
     "SELECT * FROM (
          SELECT score.*,
                 row_number() OVER (ORDER BY total DESC) AS position
            FROM score
      ) AS t
       WHERE position > ?
       ORDER BY position
       LIMIT ?"
     :binds (list (- user-position
                     (floor (/ limit 2)))
                  limit))