### PR TITLE
Use DBI logger for logging

### DIFF
--- a/src/core/logger.lisp
+++ b/src/core/logger.lisp
@@ -1,23 +1,22 @@
 (in-package :cl-user)
 (defpackage mito.logger
   (:use #:cl)
+  (:import-from #:dbi
+                #:*sql-execution-hooks*)
   (:import-from #:alexandria
                 #:delete-from-plist)
   (:export #:*mito-logger-stream*
            #:*mito-migration-logger-stream*
-           #:with-sql-logging
-           #:trace-sql
-           #:*trace-sql-hooks*))
+           #:*trace-sql-hooks*
+           #:mito-sql-logger
+           #:with-trace-sql
+           #:with-sql-logging))
 (in-package :mito.logger)
 
 (defvar *mito-logger-stream* nil)
 
 (defvar *mito-migration-logger-stream* (make-synonym-stream '*standard-output*)
   "Stream to output sql generated during migrations.")
-
-(defmacro with-sql-logging (&body body)
-  `(let ((*mito-logger-stream* *mito-migration-logger-stream*))
-     ,@body))
 
 (defun get-prev-stack ()
   (labels ((stack-call (stack)
@@ -38,7 +37,7 @@
                (let ((package (symbol-package call)))
                  (or #+sbcl (sbcl-package-p package)
                      (find (package-name package)
-                           '(:common-lisp :mito.logger :mito.db :mito.dao :mito.util)
+                           '(:common-lisp :mito.logger :mito.db :mito.dao :mito.util :dbi.logger :dbi.driver)
                            :test #'string=)))))
            (users-stack-p (stack)
              (let ((call (stack-call stack)))
@@ -47,26 +46,37 @@
                         (not (system-call-p call)))))))
 
     (loop with prev-stack = nil
-          repeat 10
           for stack in (dissect:stack)
           when (users-stack-p stack)
             do (return (stack-call stack)))))
 
-(defun default-trace-sql-hook (sql params results)
+(defun mito-sql-logger (sql params row-count took-ms prev-stack)
   (when *mito-logger-stream*
     (format *mito-logger-stream*
-            "~&~<;; ~@;~A (~{~S~^, ~}) [~D row~:P]~:[~;~:* | ~S~]~:>~%"
+            "~&~<;; ~@;~A (~{~S~^, ~}) ~@[[~D row~:P]~]~@[ (~Dms)~]~:[~;~:* | ~S~]~:>~%"
             (list sql
                   (mapcar (lambda (param)
                             (if (typep param '(simple-array (unsigned-byte 8) (*)))
                                 (map 'string #'code-char param)
                                 param))
                           params)
-                  (length results)
-                  (get-prev-stack)))))
+                  row-count
+                  took-ms
+                  prev-stack))))
 
-(defvar *trace-sql-hooks* (list #'default-trace-sql-hook))
+(defvar *trace-sql-hooks* (list #'mito-sql-logger))
 
-(defun trace-sql (sql params &optional results)
-  (dolist (hook *trace-sql-hooks*)
-    (funcall hook sql params results)))
+(defun trace-sql (sql params row-count took-ms)
+  (when *trace-sql-hooks*
+    (let ((prev-stack (get-prev-stack)))
+      (dolist (hook *trace-sql-hooks*)
+        (funcall hook sql params row-count took-ms prev-stack)))))
+
+(defmacro with-trace-sql (&body body)
+  `(let ((dbi:*sql-execution-hooks* (cons #'trace-sql
+                                          dbi:*sql-execution-hooks*)))
+     ,@body))
+
+(defmacro with-sql-logging (&body body)
+  `(let ((*mito-logger-stream* *mito-migration-logger-stream*))
+     (with-trace-sql ,@body)))


### PR DESCRIPTION
CL-DBI provides a logging feature since v0.9.0. This patch replaces Mito.Logger by it.

Compatibility note: functions in `*trace-sql-hooks*` now takes these 5 arguments, not 3.

* SQL (string)
* params (list)
* Row counts (integer or null)
* Took time in milliseconds (integer or null)
* Previous stack call (symbol, cons or null)