### PR TITLE
Allow to use DBI:PREPARE-CACHED instead of DBI:PREPARE.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,7 +11,7 @@ while ! mysql -u "$MYSQL_USER" \
       sleep 1
 done
 
-ros install fukamachi/cl-dbi
+ros install fukamachi/cl-dbi/prepare-cached
 
 ros -s mito-test
 run-prove mito-test.asd

--- a/lack-middleware-mito.asd
+++ b/lack-middleware-mito.asd
@@ -3,7 +3,7 @@
   :author "Eitaro Fukamachi"
   :license "LLGPL"
   :depends-on ("mito-core"
-               "cl-dbi")
+               "dbi")
   :components ((:module "src"
                 :components
                 ((:file "middleware")))))

--- a/mito-core.asd
+++ b/mito-core.asd
@@ -2,7 +2,7 @@
   :version "0.1"
   :author "Eitaro Fukamachi"
   :license "LLGPL"
-  :depends-on ("dbi"
+  :depends-on ((:version "dbi" "0.9.5")
                "sxql"
                "cl-ppcre"
                "closer-mop"

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -44,7 +44,8 @@
 
                                       #:deftable))
 (cl-reexport:reexport-from :mito.db
-                           :include '(#:execute-sql
+                           :include '(#:*use-prepare-cached*
+                                      #:execute-sql
                                       #:retrieve-by-sql))
 (cl-reexport:reexport-from :mito.logger
                            :include '(#:*mito-logger-stream*

--- a/src/core/logger.lisp
+++ b/src/core/logger.lisp
@@ -71,7 +71,7 @@
           when (users-call-p call)
           do (return call))))
 
-(defun mito-sql-logger (sql params row-count took-ms prev-stack)
+(defun mito-sql-logger (sql params row-count took-usec prev-stack)
   (when *mito-logger-stream*
     (format *mito-logger-stream*
             "~&~<;; ~@;~A (~{~S~^, ~}) ~@[[~D row~:P]~]~@[ (~Dms)~]~:[~;~:* | ~S~]~:>~%"
@@ -82,16 +82,16 @@
                                 param))
                           params)
                   row-count
-                  took-ms
+                  took-usec
                   prev-stack))))
 
 (defvar *trace-sql-hooks* (list #'mito-sql-logger))
 
-(defun trace-sql (sql params row-count took-ms)
+(defun trace-sql (sql params row-count took-usec)
   (when *trace-sql-hooks*
     (let ((prev-stack (get-prev-stack)))
       (dolist (hook *trace-sql-hooks*)
-        (funcall hook sql params row-count took-ms prev-stack)))))
+        (funcall hook sql params row-count took-usec prev-stack)))))
 
 (defmacro with-trace-sql (&body body)
   `(let ((dbi:*sql-execution-hooks* (cons #'trace-sql


### PR DESCRIPTION
This feature is experimental. To enable this, set `*USE-PREPARE-CACHED*` T.

ref https://github.com/fukamachi/cl-dbi/pull/56