### PR TITLE
Fixed error when insert-dao used with object having the value for the serial-key

### DIFF
--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -148,7 +148,12 @@
       (execute-sql
        (sxql:insert-into (sxql:make-sql-symbol (table-name (class-of obj)))
          (make-set-clause obj)))
-      (when serial-key
+      (when (and serial-key
+                 ;; We only want to retrieve last-insert-id
+                 ;; in case if user didn't set it manually
+                 ;; for the inserted object:
+                 (or (not (slot-boundp obj serial-key))
+                     (null (slot-value obj serial-key))))
         (setf (slot-value obj serial-key)
               (last-insert-id *connection* (table-name (class-of obj))
                               (unlispify (symbol-name-literally serial-key)))))


### PR DESCRIPTION
I encounter this error from PostgreSQL:

    2020-11-08 15:03:44.000 UTC [30315] ERROR:  currval of sequence "dist_id_seq" is not yet defined in this session
    2020-11-08 15:03:44.000 UTC [30315] STATEMENT:  SELECT currval(pg_get_serial_sequence('dist', 'id')) AS last_insert_id
    2020-11-08 15:03:44.001 UTC [30315] ERROR:  current transaction is aborted, commands ignored until end of transaction block

When trying to pass an object with `id` into the `insert-dao`.

This is a rare situation because I'm having a composite primary key on my object: `(id version)`

ID field is autoincremented, but version is not.

When I create a new object version, I call `insert-dao` on the object where ID slot has value and VERSION slot
is incremented by application code. This leads to the error, because Mito tries to fetch last insert id from the sequence.

This commit fixes this problem by not trying to fetch last insert id if its value already known.