### PR TITLE
Use the references ID column in mito:save-dao when it's bound.

### DIFF
--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -125,12 +125,15 @@
               (let ((slot-name (c2mop:slot-definition-name slot)))
                 (cond
                   ((table-column-references-column slot)
-                   (multiple-value-bind (value win)
-                       (foreign-value obj slot)
-                     (if win
-                         (list (sxql:make-sql-symbol (table-column-name slot))
-                               value)
-                         nil)))
+                   (if (slot-boundp obj slot-name)
+                       (list (sxql:make-sql-symbol (table-column-name slot))
+                             (slot-value obj slot-name))
+                       (multiple-value-bind (value win)
+                           (foreign-value obj slot)
+                         (if win
+                             (list (sxql:make-sql-symbol (table-column-name slot))
+                                   value)
+                             nil))))
                   ((not (slot-boundp obj slot-name))
                    nil)
                   (t


### PR DESCRIPTION
Before this, `(mito:create-dao :some-id "xxxx")` is not allowed and just ignored.
By this changes, it's allowed and still `(mito:create-dao :some #<obj>)` is okay.