### PR TITLE
Make MAKE-DAO-INSTANCE accept symbolic class names.

### DIFF
--- a/src/core/dao/mixin.lisp
+++ b/src/core/dao/mixin.lisp
@@ -47,6 +47,11 @@
   'dao-table-column-class)
 
 (defgeneric make-dao-instance (class &rest initargs)
+  (:method ((class-name symbol) &rest initargs)
+    (apply #'make-dao-instance
+           (find-class class-name)
+           initargs))
+  
   (:method ((class table-class) &rest initargs)
     (let* ((list (loop for (k v) on initargs by #'cddr
                        for column = (find-if (lambda (initargs)


### PR DESCRIPTION
Before ad6d1fde779fd71e7fc95c2ce380c14154ac0e42 commit `MAKE-DAO-INSTANCE` function applied `ENSURE-CLASS` to the first argument. After this commit, this behaviour was broken and the function `SELECT-BY-SQL` was broken as well, because it does not apply `ENSURE-CLASS` as other `DAO` functions do.