### PR TITLE
Fix unbound *connection* error after disconnected

### DIFF
--- a/src/core/connection.lisp
+++ b/src/core/connection.lisp
@@ -43,7 +43,7 @@
 (defun disconnect-toplevel ()
   (when (connected-p)
     (dbi:disconnect *connection*)
-    (makunbound '*connection*)))
+    (setf *connection* nil)))
 
 (defun connection-quote-character (conn)
   (ecase (connection-driver-type conn)


### PR DESCRIPTION
Function `disconnect-toplevel` calls `makunbound` on variable `*connection*`.

The following code fails unconditionally:

```lisp
(mito:disconnect-toplevel)
(mito.connection:connected-p) ; => Error: The variable *CONNECTION* is unbound.
```

This PR fixes this issue.

#106 