### PR TITLE
Record all existing migration versions on the first table creation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        lisp: [sbcl, ccl]
+        lisp: [sbcl]
 
     steps:
       - uses: actions/checkout@v1

--- a/src/migration/versions.lisp
+++ b/src/migration/versions.lisp
@@ -255,14 +255,19 @@
            (when current-version
              (let ((version (migration-file-version file)))
                (update-migration-version version))))
-         (let* ((latest-migration-file (first (last (if current-version
+         (let* ((migration-files (migration-files directory))
+                (latest-migration-file (first (last (if current-version
                                                         sql-files-to-apply
-                                                        (migration-files directory)))))
+                                                        migration-files))))
                 (version (if latest-migration-file
                              (migration-file-version latest-migration-file)
                              (generate-version))))
            (unless current-version
-             (update-migration-version version))
+             (if migration-files
+                 ;; Record all versions on the first table creation
+                 (dolist (file migration-files)
+                   (update-migration-version (migration-file-version version)))
+                 (update-migration-version version)))
            (if dry-run
                (format t "~&No problems were found while migration.~%")
                (format t "~&Successfully updated to the version ~S.~%" version)))


### PR DESCRIPTION
When creating the DB, the latest schema version was recorded until now.
New migration files created thereafter are applied sequentially.

However, it may confuse when another branch has "older" migration files, which won't be applied.

This patch fixes the problem by recording all existing schema versions on the first DB creation.