### PR TITLE
Added reference to select-by-sql in documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -270,7 +270,7 @@ The symbols are not defined directly in the system, rather they are the symbol e
 ;-> 1
 ```
 
-Use `select-dao` to build custom queries with sxql (examples below).
+Use `select-dao` to build custom queries with sxql (examples below), or `select-by-sql` in the `mito.dao` package in order to run raw SQL.
 
 ### Relationship
 


### PR DESCRIPTION
There doesn't seem to be a documented way to select with a raw SQL query, so I added a reference to `mito.dao:select-by-sql` in the README.