### PR TITLE
Fix: avoid unused variable style warnings

### DIFF
--- a/src/core/class/column.lisp
+++ b/src/core/class/column.lisp
@@ -63,7 +63,7 @@
 (defmethod initialize-instance :around ((class table-column-class) &rest rest-initargs
                                         &key name initargs ghost
                                         &allow-other-keys)
-
+  (declare (ignore ghost))
   (unless (find (symbol-name name) initargs :test #'string=)
     ;; Add the default initarg.
     (push (intern (symbol-name name) :keyword)

--- a/src/core/dao/mixin.lisp
+++ b/src/core/dao/mixin.lisp
@@ -115,7 +115,7 @@
                               (setf calledp t
                                     (slot-value object slot-name) foreign-object)))))))))
 
-(defun add-relational-readers (class initargs)
+(defun add-relational-readers (class)
   (loop for column in (table-direct-column-slots class)
         for col-type = (table-column-type column)
         when (and (symbolp col-type)
@@ -131,14 +131,14 @@
                                         &key conc-name &allow-other-keys)
   (let ((*conc-name* (first conc-name)))
     (let ((class (apply #'call-next-method class initargs)))
-      (add-relational-readers class initargs)
+      (add-relational-readers class)
       class)))
 
 (defmethod reinitialize-instance :around ((class dao-table-mixin) &rest initargs
                                           &key conc-name &allow-other-keys)
   (let ((*conc-name* (first conc-name)))
     (let ((class (apply #'call-next-method class initargs)))
-      (add-relational-readers class initargs)
+      (add-relational-readers class)
       class)))
 
 (defclass serial-pk-mixin ()

--- a/src/core/logger.lisp
+++ b/src/core/logger.lisp
@@ -48,7 +48,7 @@
     (do ((frame (sb-di:frame-down (sb-di:top-frame))
                 (sb-di:frame-down frame)))
         ((null frame))
-      (multiple-value-bind (call args info)
+      (multiple-value-bind (call)
           (sb-debug::frame-call frame)
         (let ((call (normalize-call call)))
           (when (users-call-p call)


### PR DESCRIPTION
Some variables are removed and some are ignored.

Compiling `Mito` works now without style warnings on `sbcl` 2.4.3.
The test suites are not set up on my machine so you should run the tests
at least one time to make sure nothing is breaking with this change.