### PR TITLE
Cursor support (only for PostgreSQL)

### DIFF
--- a/mito-core.asd
+++ b/mito-core.asd
@@ -2,7 +2,7 @@
   :version "0.2.0"
   :author "Eitaro Fukamachi"
   :license "LLGPL"
-  :depends-on ((:version "dbi" "0.10.0")
+  :depends-on ((:version "dbi" "0.11.1")
                "sxql"
                "cl-ppcre"
                "closer-mop"

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,7 +5,7 @@
 ("cl-dbi" .
  (:class qlot/source/ql:source-ql-upstream
   :initargs nil
-  :version "ql-upstream-48fa6fbda153414a87f5c1c5b5626ee0aed9de2e"
+  :version "ql-upstream-f58761b4da39e0559fcfbd744fa6f024182c6d94"
   :remote-url "https://github.com/fukamachi/cl-dbi.git"))
 ("cl-mysql" .
  (:class qlot/source/ql:source-ql-upstream

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,7 +5,7 @@
 ("cl-dbi" .
  (:class qlot/source/ql:source-ql-upstream
   :initargs nil
-  :version "ql-upstream-2ff41f0706180e140a31b844da4f0272e1a281cd"
+  :version "ql-upstream-48fa6fbda153414a87f5c1c5b5626ee0aed9de2e"
   :remote-url "https://github.com/fukamachi/cl-dbi.git"))
 ("cl-mysql" .
  (:class qlot/source/ql:source-ql-upstream

--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -53,8 +53,6 @@
            #:delete-by-values
            #:save-dao
            #:select-dao
-           #:*want-cursor*
-           #:fetch-dao
            #:select-by-sql
            #:includes
            #:include-foreign-objects
@@ -216,8 +214,7 @@
       (make-mito-cursor :cursor cursor
                         :class class))))
 
-(defun fetch-dao (cursor)
-  (check-type cursor mito-cursor)
+(defun fetch-dao-from-cursor (cursor)
   (let ((row (dbi:fetch (mito-cursor-cursor cursor)
                         :format :alist)))
     (when row
@@ -456,7 +453,7 @@
               (let* ((*want-cursor* t)
                      (,cursor ,select))
                 (loop ,@(and index `(for ,index from 0))
-                      for ,dao = (fetch-dao ,cursor)
+                      for ,dao = (fetch-dao-from-cursor ,cursor)
                       while ,dao
                       do (progn ,@body)))))
        (if (dbi:in-transaction *connection*)

--- a/src/core/dao.lisp
+++ b/src/core/dao.lisp
@@ -28,13 +28,16 @@
                 #:last-insert-id
                 #:execute-sql
                 #:retrieve-by-sql
-                #:table-exists-p)
+                #:table-exists-p
+                #:ensure-sql)
   (:import-from #:mito.logger
                 #:with-sql-logging)
   (:import-from #:mito.util
+                #:lispify
                 #:unlispify
                 #:symbol-name-literally
-                #:ensure-class)
+                #:ensure-class
+                #:execute-with-retry)
   (:import-from #:trivia
                 #:match
                 #:guard)
@@ -50,6 +53,8 @@
            #:delete-by-values
            #:save-dao
            #:select-dao
+           #:*want-cursor*
+           #:fetch-dao
            #:select-by-sql
            #:includes
            #:include-foreign-objects
@@ -198,6 +203,28 @@
         (update-dao obj)
         (insert-dao obj))))
 
+(defstruct mito-cursor
+  cursor
+  class)
+
+(defun select-by-sql-as-cursor (class sql &key binds)
+  (multiple-value-bind (sql yield-binds)
+      (ensure-sql sql)
+    (let* ((cursor (dbi:make-cursor *connection* sql))
+           (cursor (execute-with-retry cursor (or binds yield-binds))))
+      (make-mito-cursor :cursor cursor
+                        :class class))))
+
+(defun fetch-dao (cursor)
+  (check-type cursor mito-cursor)
+  (let ((row (dbi:fetch (mito-cursor-cursor cursor)
+                        :format :alist)))
+    (when row
+      (apply #'make-dao-instance (mito-cursor-class cursor)
+             (loop for (k . v) in row
+                   collect (intern (lispify (string-upcase k)) :keyword)
+                   collect v)))))
+
 (defun select-by-sql (class sql &key binds)
   (mapcar (lambda (result)
             (apply #'make-dao-instance class result))
@@ -305,6 +332,8 @@
                                   (expand-op arg class)) args)))
       (otherwise object))))
 
+(defparameter *want-cursor* nil)
+
 (defmacro select-dao (class &body clauses)
   (with-gensyms (sql clause results include-classes foreign-class)
     (once-only (class)
@@ -327,10 +356,12 @@
                 (dolist (,clause (list ,@clauses))
                   (when ,clause
                     (add-child ,sql ,clause)))
-                (let ((,results (select-by-sql ,class ,sql)))
-                  (dolist (,foreign-class (remove-duplicates ,include-classes))
-                    (include-foreign-objects ,foreign-class ,results))
-                  (values ,results ,sql))))))))))
+                (if *want-cursor*
+                    (select-by-sql-as-cursor ,class ,sql)
+                    (let ((,results (select-by-sql ,class ,sql)))
+                      (dolist (,foreign-class (remove-duplicates ,include-classes))
+                        (include-foreign-objects ,foreign-class ,results))
+                      (values ,results ,sql)))))))))))
 
 (defun where-and (fields-and-values class)
   (when fields-and-values

--- a/t/dao.lisp
+++ b/t/dao.lisp
@@ -240,6 +240,36 @@
 
   (dolist (class-name '(user-setting user tweet friend-relationship tweet2))
     (setf (find-class class-name) nil))
+
+  (disconnect-toplevel))
+
+(deftest cursor
+  (setf *connection* (connect-to-testdb :postgres))
+  (when (find-class 'user nil)
+    (setf (find-class 'user) nil))
+  (defclass user ()
+    ((name :col-type :text
+           :initarg :name))
+    (:metaclass dao-table-class))
+  (mito:execute-sql "DROP TABLE IF EXISTS \"user\"")
+  (mito:ensure-table-exists 'user)
+  (mito:create-dao 'user :name "Eitaro")
+  (mito:create-dao 'user :name "Btaro")
+  (mito:create-dao 'user :name "Charlie")
+  (dbi:with-transaction *connection*
+    (let* ((*want-cursor* t)
+           (cursor (mito.dao:select-dao 'user
+                     (where (:like :name "%aro")))))
+      (ok (typep cursor 'mito.dao::mito-cursor))
+      (let ((row (mito.dao:fetch-dao cursor)))
+        (ok (typep row 'user))
+        (ok (equal (slot-value row 'name) "Eitaro")))
+      (let ((row (mito.dao:fetch-dao cursor)))
+        (ok (typep row 'user))
+        (ok (equal (slot-value row 'name) "Btaro")))
+      (ok (null (mito.dao:fetch-dao cursor)))))
+  (when (find-class 'user nil)
+    (setf (find-class 'user) nil))
   (disconnect-toplevel))
 
 (deftest foreign-slots

--- a/t/dao.lisp
+++ b/t/dao.lisp
@@ -257,17 +257,17 @@
   (mito:create-dao 'user :name "Btaro")
   (mito:create-dao 'user :name "Charlie")
   (dbi:with-transaction *connection*
-    (let* ((*want-cursor* t)
+    (let* ((mito.dao::*want-cursor* t)
            (cursor (mito.dao:select-dao 'user
                      (where (:like :name "%aro")))))
       (ok (typep cursor 'mito.dao::mito-cursor))
-      (let ((row (mito.dao:fetch-dao cursor)))
+      (let ((row (mito.dao::fetch-dao-from-cursor cursor)))
         (ok (typep row 'user))
         (ok (equal (slot-value row 'name) "Eitaro")))
-      (let ((row (mito.dao:fetch-dao cursor)))
+      (let ((row (mito.dao::fetch-dao-from-cursor cursor)))
         (ok (typep row 'user))
         (ok (equal (slot-value row 'name) "Btaro")))
-      (ok (null (mito.dao:fetch-dao cursor)))))
+      (ok (null (mito.dao::fetch-dao-from-cursor cursor)))))
 
   (let ((records '()))
     (do-cursor (dao (mito.dao:select-dao 'user) i)

--- a/t/dao.lisp
+++ b/t/dao.lisp
@@ -268,6 +268,17 @@
         (ok (typep row 'user))
         (ok (equal (slot-value row 'name) "Btaro")))
       (ok (null (mito.dao:fetch-dao cursor)))))
+
+  (let ((records '()))
+    (do-cursor (dao (mito.dao:select-dao 'user) i)
+      (push (cons i dao) records)
+      (when (<= 1 i)
+        (return)))
+    (ok (= (length records) 2))
+    (ok (every (lambda (record)
+                 (typep (cdr record) 'user))
+               records)))
+
   (when (find-class 'user nil)
     (setf (find-class 'user) nil))
   (disconnect-toplevel))


### PR DESCRIPTION
This adds an RDB's CURSOR support to `select-dao`, which can reduce memory usage since it won't load whole results on memory.

A new macro `do-cursor` loops through rows one by one as a DAO:

```common-lisp
(do-cursor (dao (select-dao 'user
                  (where (:< "2024-07-01" :created_at))))
  ;; Can be a more complex condition
  (when (equal (user-name dao) "Eitaro")
    (return dao))

;; Same but without using CURSOR
(loop for dao in (select-dao 'user
                   (where (:< "2024-07-01" :created_at)))
      when (equal (user-name dao) "Eitaro")
      do (return dao))
```

It requires DBI v0.11.1 or above.