### PR TITLE
Fixing c2mop:direct-slot-definition-class methods to return a class

### DIFF
--- a/src/core/class/table.lisp
+++ b/src/core/class/table.lisp
@@ -141,7 +141,7 @@
       class)))
 
 (defmethod c2mop:direct-slot-definition-class ((class table-class) &key &allow-other-keys)
-  'table-column-class)
+  (find-class 'table-column-class))
 
 (defmethod c2mop:effective-slot-definition-class ((class table-class) &rest initargs)
   (declare (ignorable initargs))

--- a/src/core/dao/mixin.lisp
+++ b/src/core/dao/mixin.lisp
@@ -76,7 +76,7 @@
 (defclass dao-table-mixin (table-class) ())
 
 (defmethod c2mop:direct-slot-definition-class ((class dao-table-mixin) &key)
-  'dao-table-column-class)
+  (find-class 'dao-table-column-class))
 
 (defmethod c2mop:effective-slot-definition-class ((class dao-table-mixin) &rest initargs)
   (declare (ignorable initargs))

--- a/src/core/dao/table.lisp
+++ b/src/core/dao/table.lisp
@@ -39,7 +39,7 @@
                       :initform '(t))))
 
 (defmethod c2mop:direct-slot-definition-class ((class dao-table-class) &key)
-  'dao-table-column-class)
+  (find-class 'dao-table-column-class))
 
 (defmethod c2mop:effective-slot-definition-class ((class dao-table-class) &rest initargs)
   (declare (ignorable initargs))

--- a/src/core/dao/view.lisp
+++ b/src/core/dao/view.lisp
@@ -19,7 +19,7 @@
        :reader dao-table-view-as-query)))
 
 (defmethod c2mop:direct-slot-definition-class ((class dao-table-view) &key)
-  'dao-table-column-class)
+  (find-class 'dao-table-column-class))
 
 (defmethod c2mop:effective-slot-definition-class ((class dao-table-view) &rest initargs)
   (declare (ignorable initargs))


### PR DESCRIPTION
Right now they return symbols, which is not the correct return type based on the AMOP Book Specification which is the official specification adopted by the ANSI Spec.

See
https://lisp-docs.github.io/cl-language-reference/meta-object-protocol/dictionary/direct-slot-definition-class

and

https://lisp-docs.github.io/cl-language-reference/meta-object-protocol/dictionary/effective-slot-definition-class

Or http://metamodular.com/CLOS-MOP/direct-slot-definition-class.html

and

http://metamodular.com/CLOS-MOP/effective-slot-definition-class.html