### PR TITLE
generate-migrations now accepts a statement separator

### DIFF
--- a/src/migration/versions.lisp
+++ b/src/migration/versions.lisp
@@ -177,7 +177,7 @@
          (1+ current-version)
          1))))
 
-(defun generate-migrations (directory &key force)
+(defun generate-migrations (directory &key force (statement-separator ""))
   (let ((schema.sql (merge-pathnames #P"schema.sql" directory))
         (directory (merge-pathnames #P"migrations/" directory))
         (current-version (current-migration-version)))
@@ -222,7 +222,7 @@
                  (with-quote-char
                      (map nil
                           (lambda (ex)
-                            (format out "~&~A;~%" (sxql:yield ex)))
+                            (format out "~&~A;~%~A" (sxql:yield ex) statement-separator))
                           expressions))))
              (let ((sxql:*use-placeholder* nil))
                (with-open-file (out schema.sql


### PR DESCRIPTION
For multiple database connectors to do migrations with multiple statements, including `cl-dbi`, the statements must be separated by `--;;` on a new line. This change provides a way to provide a custom separator when generating migrations.

The default functionality stays the same. This change provides the flexibility to specify a statement separator so that `sxql` and `cl-dbi` will work with the generated statements.

Note that to test the functionality, multiple changes have to be done compared to the state of the DB in order to see multiple statements generated.