### PR TITLE
Changed the syntax of the qlfile to avoid a qlot install issue

### DIFF
--- a/qlfile
+++ b/qlfile
@@ -1,5 +1,5 @@
 ql cl-dbi :upstream
 ql cl-mysql :upstream
-ql dissect :upstream
+git dissect ssh://git@codeberg.org/shinmera/dissect.git
 ql sxql :upstream
 ql rove :upstream

--- a/qlfile
+++ b/qlfile
@@ -1,5 +1,5 @@
 ql cl-dbi :upstream
 ql cl-mysql :upstream
-git dissect ssh://git@codeberg.org/shinmera/dissect.git
+git dissect https://codeberg.org/shinmera/dissect.git
 ql sxql :upstream
 ql rove :upstream


### PR DESCRIPTION
The `qlot install` and `qlot update` commands are broken because of some qlot error with dissect:

```bash
➜  mito git:(col-type-effective-slot-bug-fix) ✗ qlot install
Installing Quicklisp to /Users/myuser/mito/.qlot/...
Reading '/Users/myuser/mito/qlfile'...
✓ [1/6] quicklisp  Installed "quicklisp" version "2026-01-01". (2.7s)
✓ [2/6] cl-mysql  Installed "cl-mysql" version "ql-upstream-b273cf772f13a525b534f5ee58bf36fb733204f3". (4.6s)
✓ [4/6] rove  Installed "rove" version "ql-upstream-1a4474901e7ab49e8184241dd88e74c95233195a". (4.7s)
✓ [3/6] sxql  Installed "sxql" version "ql-upstream-72c1c8c1642a572fcd2039304cd10ef56925c8c1". (4.8s)
● [5/6] cl-dbi  Running git clone.
⨯ [6/6] dissect  Failed to install

Unexpected error: Not supported upstream URL: https://codeberg.org/shinmera/dissect.git
This could be a bug in Qlot.
Report it at https://github.com/fukamachi/qlot/issues/new/choose.
Please attach the stack trace dumped to '/var/folders/l9/jdhc4m5s6k51lcxs1r0426bw0000gn/T/qlot-error-EK8UGS9Z.log'.
```

I don't know if this is a qlot issue, or a mito qlfile related issue, but regardless, doing a mito install right now is not working.

This PR addresses this issue by changing the qlfile syntax to use git instead. Note that the upstream repository is actually the same. After this change `qlot install` works.

Here's the log for reference:

```
Backtrace for: #<SB-THREAD:THREAD tid=259 "main thread" RUNNING {7005590473}>
0: ((LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE))
1: ((FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX))
2: (SB-IMPL::%WITH-STANDARD-IO-SYNTAX #<FUNCTION (FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX) {1014E1BBB}>)
3: (UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX #<FUNCTION (LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE) {700BF912AB}> :PACKAGE :CL)
4: (UIOP/IMAGE:PRINT-CONDITION-BACKTRACE #<SIMPLE-ERROR "Not supported upstream URL: ~A" {700BF547F3}> :STREAM #<SB-SYS:FD-STREAM for "file /var/folders/l9/jdhc4m5s6k51lcxs1r0426bw0000gn/T/qlot-error-EK8UGS9Z.log" {700BF91143}> :COUNT NIL)
5: ((FLET "BEFORE19" :IN QLOT/CLI:QLOT-COMMAND) #<SB-SYS:FD-STREAM for "file /var/folders/l9/jdhc4m5s6k51lcxs1r0426bw0000gn/T/qlot-error-EK8UGS9Z.log" {700BF91143}> #P"/var/folders/l9/jdhc4m5s6k51lcxs1r0426bw0000gn/T/qlot-error-EK8UGS9Z.log")
6: (UIOP/STREAM:CALL-WITH-TEMPORARY-FILE #<FUNCTION (FLET "BEFORE19" :IN QLOT/CLI:QLOT-COMMAND) {1014E169B}> :WANT-STREAM-P T :WANT-PATHNAME-P T :DIRECTION :OUTPUT :KEEP T :AFTER NIL :DIRECTORY NIL :TYPE "log" :PREFIX "qlot-error-" :SUFFIX "" :ELEMENT-TYPE NIL :EXTERNAL-FORMAT NIL)
7: ((LAMBDA (QLOT/CLI::C) :IN QLOT/CLI:QLOT-COMMAND) #<SIMPLE-ERROR "Not supported upstream URL: ~A" {700BF547F3}>)
8: (SB-KERNEL::%SIGNAL #<SIMPLE-ERROR "Not supported upstream URL: ~A" {700BF547F3}>)
9: (ERROR #<SIMPLE-ERROR "Not supported upstream URL: ~A" {700BF547F3}>)
10: (LPARALLEL.KERNEL-UTIL::RECEIVE-RESULTS #S(LPARALLEL.KERNEL:CHANNEL :QUEUE #S(LPARALLEL.CONS-QUEUE:CONS-QUEUE :IMPL #S(LPARALLEL.RAW-QUEUE:RAW-QUEUE :HEAD NIL :TAIL NIL) :LOCK #<SB-THREAD:MUTEX "Anonymous lock" free owner=0> :CVAR #<SB-THREAD:WAITQUEUE Anonymous condition variable {7007B1C233}>) :KERNEL #<LPARALLEL.KERNEL:KERNEL :NAME "lparallel" :WORKER-COUNT 4 :USE-CALLER NIL :ALIVE T :SPIN-COUNT 2000 {700C0A0023}>) #<unavailable argument> #<unavailable argument>)
11: (LPARALLEL.COGNATE::PMAP-ITERATE #<FUNCTION MAPC> #<FUNCTION (LAMBDA (QLOT/PROGRESS::JOB) :IN QLOT/PROGRESS:RUN-IN-PARALLEL) {700C0A01EB}> ((#<QLOT/SOURCE/DIST:SOURCE-DIST https://beta.quicklisp.org/dist/quicklisp.txt 2026-01-01 {700C0A09C3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM cl-dbi https://github.com/fukamachi/cl-dbi.git ref-5cf8b754affee7b20782e64ac7c80db9a45e488b {700C158CF3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM cl-mysql https://github.com/hackinghat/cl-mysql.git ref-b273cf772f13a525b534f5ee58bf36fb733204f3 {700C0A0253}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM dissect NIL {700C158AC3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM sxql https://github.com/fukamachi/sxql.git ref-72c1c8c1642a572fcd2039304cd10ef56925c8c1 {700C0A1073}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM rove https://github.com/fukamachi/rove.git ref-1a4474901e7ab49e8184241dd88e74c95233195a {700C0A6853}>)) 6 4)
12: (LPARALLEL.COGNATE:PMAPC #<FUNCTION (LAMBDA (QLOT/PROGRESS::JOB) :IN QLOT/PROGRESS:RUN-IN-PARALLEL) {700C0A01EB}> (#<QLOT/SOURCE/DIST:SOURCE-DIST https://beta.quicklisp.org/dist/quicklisp.txt 2026-01-01 {700C0A09C3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM cl-dbi https://github.com/fukamachi/cl-dbi.git ref-5cf8b754affee7b20782e64ac7c80db9a45e488b {700C158CF3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM cl-mysql https://github.com/hackinghat/cl-mysql.git ref-b273cf772f13a525b534f5ee58bf36fb733204f3 {700C0A0253}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM dissect NIL {700C158AC3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM sxql https://github.com/fukamachi/sxql.git ref-72c1c8c1642a572fcd2039304cd10ef56925c8c1 {700C0A1073}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM rove https://github.com/fukamachi/rove.git ref-1a4474901e7ab49e8184241dd88e74c95233195a {700C0A6853}>))
13: (QLOT/PROGRESS:RUN-IN-PARALLEL #<FUNCTION (LAMBDA (QLOT/INSTALL::SOURCE) :IN QLOT/INSTALL::APPLY-QLFILE-TO-QLHOME) {700C0A027B}> (#<QLOT/SOURCE/DIST:SOURCE-DIST https://beta.quicklisp.org/dist/quicklisp.txt 2026-01-01 {700C0A09C3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM cl-dbi https://github.com/fukamachi/cl-dbi.git ref-5cf8b754affee7b20782e64ac7c80db9a45e488b {700C158CF3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM cl-mysql https://github.com/hackinghat/cl-mysql.git ref-b273cf772f13a525b534f5ee58bf36fb733204f3 {700C0A0253}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM dissect NIL {700C158AC3}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM sxql https://github.com/fukamachi/sxql.git ref-72c1c8c1642a572fcd2039304cd10ef56925c8c1 {700C0A1073}> #<QLOT/SOURCE/QL:SOURCE-QL-UPSTREAM rove https://github.com/fukamachi/rove.git ref-1a4474901e7ab49e8184241dd88e74c95233195a {700C0A6853}>) :CONCURRENCY 4 :JOB-HEADER-FN #<FUNCTION (LAMBDA (QLOT/INSTALL::SOURCE) :IN QLOT/INSTALL::APPLY-QLFILE-TO-QLHOME) {700C0A6DAB}> :FAILED-FN #<FUNCTION (LAMBDA NIL :IN QLOT/INSTALL::APPLY-QLFILE-TO-QLHOME) {7008BB77AB}>)
14: (QLOT/INSTALL::APPLY-QLFILE-TO-QLHOME #P"/Users/myuser/mito/qlfile" #P"/Users/myuser/mito/.qlot/" :IGNORE-LOCK NIL :PROJECTS NIL :CONCURRENCY NIL)
15: (QLOT/INSTALL:INSTALL-QLFILE #P"/Users/myuser/mito/qlfile" :QUICKLISP-HOME NIL :INSTALL-DEPS T :CONCURRENCY NIL)
16: (QLOT/INSTALL:INSTALL-PROJECT #P"/Users/myuser/mito/" :INSTALL-DEPS T :CACHE-DIRECTORY NIL :CONCURRENCY NIL)
17: (UIOP/FILESYSTEM:CALL-WITH-CURRENT-DIRECTORY #P"/Users/myuser/mito/" #<FUNCTION (LAMBDA NIL :IN QLOT/CLI::%QLOT-COMMAND) {70055A024B}>)
18: (QLOT/CLI:QLOT-COMMAND "install")
19: (QLOT/CLI:MAIN)
20: (SB-INT:SIMPLE-EVAL-IN-LEXENV (QLOT/CLI:MAIN) #<NULL-LEXENV>)
21: (EVAL (QLOT/CLI:MAIN))
22: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"/opt/homebrew/Cellar/roswell/24.10.115/etc/roswell/init.lisp\"))") (:EVAL . "(ros:run '((:load\"/Users/myuser/.roswell/init.lisp\")))") (:EVAL . "(let (*load-verbose*) (load \"/Users/myuser/.qlot/qlot/.bundle-libs/setup.lisp\"))") (:EVAL . "(let (*load-verbose*) (asdf:load-asd #P\"/Users/myuser/.qlot/qlot/qlot.asd\"))") (:EVAL . "(let ((*standard-output* (make-broadcast-stream)) (*trace-output* (make-broadcast-stream))) (asdf:load-system :qlot/cli))") (:EVAL . "(qlot/cli:main)") (:QUIT)))
23: (SB-IMPL::TOPLEVEL-INIT)
24: ((FLET SB-UNIX::BODY :IN SB-IMPL::START-LISP))
25: ((FLET "WITHOUT-INTERRUPTS-BODY-3" :IN SB-IMPL::START-LISP))
26: (SB-IMPL::%START-LISP)
Above backtrace due to this condition:
Not supported upstream URL: https://codeberg.org/shinmera/dissect.git
```