### PR TITLE
Treat empty string as nil when inflating datetime/date columns

### DIFF
--- a/src/core/dao/column.lisp
+++ b/src/core/dao/column.lisp
@@ -105,17 +105,19 @@
            (truncate value)
          (local-time:universal-to-timestamp sec :nsec (* (round (* nsec 1000000)) 1000))))
       (string
-       (local-time:parse-timestring value :date-time-separator #\Space))
+       (unless (string= value "")
+         (local-time:parse-timestring value :date-time-separator #\Space)))
       (null nil)))
   (:method ((col-type (eql :date)) value)
     (etypecase value
       (integer
        (local-time:universal-to-timestamp value))
       (string
-       (ppcre:register-groups-bind ((#'parse-integer year month day))
-           ("^(\\d{4})-(\\d{2})-(\\d{2})$" value)
-         (local-time:universal-to-timestamp
-           (encode-universal-time 0 0 0 day month year))))
+       (unless (string= value "")
+         (ppcre:register-groups-bind ((#'parse-integer year month day))
+             ("^(\\d{4})-(\\d{2})-(\\d{2})$" value)
+           (local-time:universal-to-timestamp
+             (encode-universal-time 0 0 0 day month year)))))
       (null nil)))
   (:method ((col-type (eql :timestamp)) value)
     (inflate-for-col-type :datetime value))

--- a/t/class.lisp
+++ b/t/class.lisp
@@ -2,7 +2,9 @@
   (:use #:cl
         #:rove
         #:mito.class
-        #:mito-test.util))
+        #:mito-test.util)
+  (:import-from #:mito.dao.column
+                #:inflate-for-col-type))
 (in-package #:mito-test.class)
 
 (deftest create-table
@@ -326,3 +328,12 @@
     created_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ
 )"))
+
+(deftest inflate-for-col-type-null-string
+  (testing "empty string treated as nil for nullable timestamp/date columns"
+    (ok (null (inflate-for-col-type :datetime ""))
+        "empty string inflates to nil for :datetime")
+    (ok (null (inflate-for-col-type :timestamp ""))
+        "empty string inflates to nil for :timestamp")
+    (ok (null (inflate-for-col-type :date ""))
+        "empty string inflates to nil for :date")))


### PR DESCRIPTION
## What

In `inflate-for-col-type`, handle empty string `""` as `nil` for `:datetime` and `:date` col-types (and their aliases `:timestamp`, `:timestamptz`).

## Why

When a column is declared `(or :null :timestamp)` and the database stores `""` instead of NULL — which can happen with data imports, external tools, or direct SQL inserts that use empty string for missing dates — `local-time:parse-timestring` is called with `""` and raises an error. An empty string is never a valid timestamp, so treating it as `nil` is the right behavior.

Fixes #197.